### PR TITLE
Fix typo in C++ sources classifier

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -63,7 +63,7 @@ task cppHeadersZip(type: Zip) {
 task cppSourceZip(type: Zip) {
     destinationDirectory = outputsFolder
     archiveBaseName = zipBaseName
-    classifier = "source"
+    classifier = "sources"
 
     from(licenseFile) {
         into '/'


### PR DESCRIPTION
To stay consistent with what we have elsewhere.