### PR TITLE
Bump publish version number

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 ext.licenseFile = files("$rootDir/LICENSE.txt")
 
-def pubVersion = '0.0.1'
+def pubVersion = '0.0.2'
 
 def outputsFolder = file("$buildDir/allOutputs")
 


### PR DESCRIPTION
This is to publish the 2022 version of the vendordep. Needs a tag push after merge.