### PR TITLE
Don't allocate the same I/O twice

### DIFF
--- a/src/main/native/cpp/romi/OnBoardIO.cpp
+++ b/src/main/native/cpp/romi/OnBoardIO.cpp
@@ -19,6 +19,7 @@ OnBoardIO::OnBoardIO(OnBoardIO::ChannelMode dio1, OnBoardIO::ChannelMode dio2) {
   }
   if (dio2 == ChannelMode::INPUT) {
     m_buttonC = std::make_unique<frc::DigitalInput>(2);
+  } else {
     m_redLed = std::make_unique<frc::DigitalOutput>(2);
   }
 }


### PR DESCRIPTION
This was fixed in the wpilibc example, but I guess nobody uses this?